### PR TITLE
Add elpa autoload directives

### DIFF
--- a/color-theme-solarized.el
+++ b/color-theme-solarized.el
@@ -13,6 +13,7 @@
 (eval-when-compile
   (require 'color-theme))
 
+;;;###autoload
 (defun color-theme-solarized (mode)
   "Color theme by Ethan Schoonover, created 2011-03-24.
 Ported to Emacs by Greg Pfeil, http://ethanschoonover.com/solarized."
@@ -110,11 +111,12 @@ Ported to Emacs by Greg Pfeil, http://ethanschoonover.com/solarized."
        ;; show-paren
        (show-paren-match-face ((t (:background ,cyan :foreground ,base3))))
        (show-paren-mismatch-face ((t (:background ,red :foreground ,base3))))))))
-
+;;;###autoload
 (defun color-theme-solarized-dark ()
   (interactive)
   (color-theme-solarized 'dark))
 
+;;;###autoload
 (defun color-theme-solarized-light ()
   (interactive)
   (color-theme-solarized 'light))


### PR DESCRIPTION
Adds package.el compatible autoload comments.

Makes the theme "just work" with [technomancy/emacs-starter-kit](https://github.com/technomancy/emacs-starter-kit).

> You should use ;;;###autoload comments everywhere appropriate. package.el extracts these for use during package activation. Note you may want to do this for more than just function definitions; for instance if you have a new major mode, you will want to add an autoload to add to auto-mode-alist. 

_http://tromey.com/elpa/upload.html_
