### PR TITLE
Fix tty emacs colour handling on OS X

### DIFF
--- a/solarized-definitions.el
+++ b/solarized-definitions.el
@@ -111,7 +111,7 @@ will use the 256 degraded color mode."
             (progn
               ;; We're operating in reduced-behaviour 8-colour terminal, we need to
               ;; remap a bunch of the colours as per the solarized table.
-              (message "Warning: 8-color terminal detected, emacs-color-theme-solziared operating with degraded colors.")
+              (message "Warning: 8-color terminal detected, emacs-color-theme-solarized operating with degraded colors.")
               (setq base03 blue)
               (setq base02 blue) ;; This is what solarized spec says but it's unreadable for dark.
               (setq base01 base2)

--- a/solarized-definitions.el
+++ b/solarized-definitions.el
@@ -85,11 +85,6 @@ will use the 256 degraded color mode."
           (bold      (if solarized-bold 'bold 'normal))
           (underline (if solarized-underline t nil))
           (italic    (if solarized-italic 'italic 'normal)))
-      (when (eq 'light mode)
-        (rotatef base03 base3)
-        (rotatef base02 base2)
-        (rotatef base01 base1)
-        (rotatef base00 base0))
       (unless window-system
           ;; If we're a tty, we need to tell emacs that the standard terminal colours
           ;; have been overridden, otherwise the "closest matching terminal colour" code
@@ -123,6 +118,11 @@ will use the 256 degraded color mode."
             (add-hook 'term-setup-hook 'color-theme-solarized-light)
             (add-hook 'term-setup-hook 'color-theme-solarized-dark))
         )
+      (when (eq 'light mode)
+        (rotatef base03 base3)
+        (rotatef base02 base2)
+        (rotatef base01 base1)
+        (rotatef base00 base0))
       `((;; basic
          (default ((t (:foreground ,base0 :background ,base03))))
          (cursor

--- a/solarized-definitions.el
+++ b/solarized-definitions.el
@@ -313,7 +313,10 @@ will use the 256 degraded color mode."
           ((t (:foreground ,yellow :weight ,bold :slant ,italic))))
          (message-header-subject ((t (:foreground ,base00))))
          (message-header-cc ((t (:foreground ,green :weight ,bold))))
-         (message-header-to ((t (:foreground ,base1 :weight ,bold)))))
+         (message-header-to ((t (:foreground ,base1 :weight ,bold))))
+         ;; buff-menu+
+         (buffer-menu-file-name ((t (:foreground ,base0))))
+	 )
         ((foreground-color . ,base0)
          (background-color . ,base03)
          (background-mode . ,mode)

--- a/solarized-definitions.el
+++ b/solarized-definitions.el
@@ -97,17 +97,30 @@ will use the 256 degraded color mode."
           (tty-color-define "magenta" 5 (tty-color-standard-values magenta))
           (tty-color-define "cyan"    6 (tty-color-standard-values cyan))
           (tty-color-define "white"   7 (tty-color-standard-values base2))
-          (when (> (display-color-cells (selected-frame)) 8)
-            ;; TODO: If we don't support 16 colour palette we probably ought to issue a warning
-            ;; since most of the base colours for Solarized require it in this setup.
-            (tty-color-define "brightblack"    8 (tty-color-standard-values base03))
-            (tty-color-define "brightred"      9 (tty-color-standard-values orange))
-            (tty-color-define "brightgreen"   10 (tty-color-standard-values base01))
-            (tty-color-define "brightyellow"  11 (tty-color-standard-values base00))
-            (tty-color-define "brightblue"    12 (tty-color-standard-values base0))
-            (tty-color-define "brightmagenta" 13 (tty-color-standard-values violet))
-            (tty-color-define "brightcyan"    14 (tty-color-standard-values base1))
-            (tty-color-define "brightwhite"   15 (tty-color-standard-values base3))
+          (if (> (display-color-cells (selected-frame)) 8)
+            (progn
+              (tty-color-define "brightblack"    8 (tty-color-standard-values base03))
+              (tty-color-define "brightred"      9 (tty-color-standard-values orange))
+              (tty-color-define "brightgreen"   10 (tty-color-standard-values base01))
+              (tty-color-define "brightyellow"  11 (tty-color-standard-values base00))
+              (tty-color-define "brightblue"    12 (tty-color-standard-values base0))
+              (tty-color-define "brightmagenta" 13 (tty-color-standard-values violet))
+              (tty-color-define "brightcyan"    14 (tty-color-standard-values base1))
+              (tty-color-define "brightwhite"   15 (tty-color-standard-values base3))
+              )
+            (progn
+              ;; We're operating in reduced-behaviour 8-colour terminal, we need to
+              ;; remap a bunch of the colours as per the solarized table.
+              (message "Warning: 8-color terminal detected, emacs-color-theme-solziared operating with degraded colors.")
+              (setq base03 blue)
+              (setq base02 blue) ;; This is what solarized spec says but it's unreadable for dark.
+              (setq base01 base2)
+              (setq base00 base2)
+              (setq base0  cyan)
+              (setq base1  blue)
+              ;; (setq base2  base2) ;; Unchanged
+              (setq base3  base2)
+              )
             )
           ;; This may well be happening before terminal is initialized, depending on how
           ;; we're being invoked, so we set up a hook to reapply our colours after the


### PR DESCRIPTION
 * Add definition of solarized terminal colours so that closest-colour matching works for tty emacs.
   * This ensures that the correct colour index is used in terminals, regardless of what colour value is being asked for by color-theme-solarized.
   * If the correct colour values are set, it ensures that the remapped Solarized terminal colours play nice with anything else in emacs trying to choose the right tty colour to display.
 * Adjust colour table values so that:
   * "Gen RGB" matches those set by Solarized OS X Terminal.app profiles.
   * "Degraded" matches the colour-profile-mangled version of the OS X Terminal.app profile colours.
   * I'm not entirely sure this is the intent of the values in those columns, so maybe they should be in a new column rather than overwriting the old values.
 * Add face for buff-menu+ filename.