### PR TITLE
Make diff-mode not ugly

### DIFF
--- a/solarized-definitions.el
+++ b/solarized-definitions.el
@@ -96,6 +96,7 @@ will use the 256 degraded color mode."
         (rotatef base00 base0))
       `((;; basic
          (default ((t (:foreground ,base0 ,:background ,base03))))
+         (shadow ((t (:foreground, base01))))
          (cursor
           ((t (:foreground ,base0 :background ,base03 :inverse-video t))))
          (escape-glyph-face ((t (:foreground ,red))))
@@ -142,13 +143,14 @@ will use the 256 degraded color mode."
          (custom-state ((t (:foreground ,green))))
          (custom-variable-tag ((t (:foreground ,orange :weight ,bold))))
          ;; diff
-         (diff-added ((t (:foreground ,green :inverse-video t))))
-         (diff-changed ((t (:foreground ,yellow :inverse-video t))))
-         (diff-removed ((t (:foreground ,red :inverse-video t))))
-         (diff-header ((t (:background ,base01))))
-         (diff-file-header
-          ((t (:background ,base1 :foreground ,base01 :weight ,bold))))
-         (diff-refine-change ((t (:background ,base1))))
+         (diff-changed       ((t (:foreground ,yellow))))
+         (diff-added         ((t (:foreground ,cyan))))
+         (diff-removed       ((t (:foreground ,red))))
+         (diff-header        ((t (:background ,base02))))
+         (diff-file-header   ((t (:background ,base02
+                                  :foreground ,base01
+                                  :weight     ,bold))))
+         (diff-refine-change ((t (:background ,base02))))
          ;; IDO
          (ido-only-match ((t (:foreground ,green))))
          (ido-subdir ((t (:foreground ,blue))))


### PR DESCRIPTION
Make diff-mode not look like my cat barfed on the screen after eating a mouse.

Basically 4 things happened:
- `diff-{remove,add,change}` no longer `:inverse-video`; it was painful to look at.
- `diff-add` is now cyan, not green. The green is a sort of ugly brown-green. A diff with too many added lines looked like barf.
- `base{0,1}` are for foreground, and `base{2,3}` are for background. I'm sure there are situations where it's OK to break this, but `diff-{header,file-header,refine-change}` are not the place.
- define the face `shadow`; it's inherited by `diff-context`.

Happy hacking!
