### PR TITLE
Cursor hidden in OS X

### DIFF
--- a/solarized-definitions.el
+++ b/solarized-definitions.el
@@ -115,7 +115,7 @@ in order to expand or compress the tonal range displayed."
         `((;; basic
            (default ((t (:foreground ,base0 ,:background ,back))))
            (cursor
-            ((t (:foreground ,base0 :background ,base03 :inverse-video t))))
+            ((t (:foreground ,base02 :background ,base1 :inverse-video t)))
            (escape-glyph-face ((t (:foreground ,red))))
            (fringe ((t (:foreground ,base01 :background ,base02))))
            (linum ((t (:foreground ,base01 :background ,base02))))


### PR DESCRIPTION
As per [this comment](https://github.com/sellout/emacs-color-theme-solarized/issues/34#issuecomment-2621406) it seems that changing the cursor color reveals it in both the light and dark themes.  Was only able to confirm for OS X 10.7.2, hopefully others out there can confirm for other OS.
