### PR TITLE
Adjusted color-theme dependency to 6.5.5

### DIFF
--- a/color-theme-solarized-pkg.el
+++ b/color-theme-solarized-pkg.el
@@ -1,1 +1,1 @@
-(define-package "color-theme-solarized" "%%version%%" "Solarized themes for Emacs" '((color-theme "6.6.1")))
+(define-package "color-theme-solarized" "%%version%%" "Solarized themes for Emacs" '((color-theme "6.5.5")))


### PR DESCRIPTION
I have changed required version of color-theme from 6.6.1 to 6.5.5. I do not know why but maintainer of the package downgraded package in marmalade repo (before it was 6.6.1 which doesn't exist anyway).

Fortunately it works with 6.5.5 also.
