### PR TITLE
Autoload solarized them into custom-theme-load-path

### DIFF
--- a/color-theme-solarized-pkg.el
+++ b/color-theme-solarized-pkg.el
@@ -1,1 +1,1 @@
-(define-package "color-theme-solarized" "%%version%%" "Solarized themes for Emacs" '((color-theme "6.5.5")))
+(define-package "color-theme-solarized" "%%version%%" "Solarized themes for Emacs")

--- a/color-theme-solarized.el
+++ b/color-theme-solarized.el
@@ -29,7 +29,7 @@ Ported to Emacs by Greg Pfeil, http://ethanschoonover.com/solarized."
    (let* ((definitions (solarized-color-definitions mode))
           (faces (first definitions))
           (variables (second definitions)))
-       (solarized-color-definitions mode)
+     (solarized-color-definitions mode)
      `(,(intern (concat "color-theme-solarized-" (symbol-name mode)))
        ,variables
        ,@faces))))
@@ -43,6 +43,7 @@ Ported to Emacs by Greg Pfeil, http://ethanschoonover.com/solarized."
 (defun color-theme-solarized-light ()
   (interactive)
   (color-theme-solarized 'light))
+
 
 (add-to-list 'color-themes
              `(color-theme-solarized-light

--- a/solarized-dark-theme.el
+++ b/solarized-dark-theme.el
@@ -2,6 +2,4 @@
          (locate-file "solarized-definitions.el" custom-theme-load-path
                       '("c" "")))
 
-(load-into-load-path)
-
 (create-solarized-theme dark)

--- a/solarized-definitions.el
+++ b/solarized-definitions.el
@@ -85,14 +85,14 @@ the \"Gen RGB\" column in solarized-definitions.el to improve them further."
 
 (defun solarized-color-definitions (mode)
   (flet ((find-color (name)
-           (let ((index (if window-system
-                            (if solarized-degrade
-                                3
-			      (if solarized-broken-srgb 2 1))
-			  (if (= solarized-termcolors 256)
-			      3
-			    4))))
-             (nth index (assoc name solarized-colors)))))
+                     (let ((index (if window-system
+                                      (if solarized-degrade
+                                          3
+                                        (if solarized-broken-srgb 2 1))
+                                    (if (= solarized-termcolors 256)
+                                        3
+                                      4))))
+                       (nth index (assoc name solarized-colors)))))
     (let ((base03      (find-color 'base03))
           (base02      (find-color 'base02))
           (base01      (find-color 'base01))
@@ -144,7 +144,7 @@ the \"Gen RGB\" column in solarized-definitions.el to improve them further."
               (bg-violet `(:background ,violet))
               (bg-blue `(:background ,blue))
               (bg-cyan `(:background ,cyan))
-              
+
               (fg-base03 `(:foreground ,base03))
               (fg-base02 `(:foreground ,base02))
               (fg-base01 `(:foreground ,base01))
@@ -458,9 +458,9 @@ the \"Gen RGB\" column in solarized-definitions.el to improve them further."
        (apply 'custom-theme-set-faces ',theme-name ',theme-faces)
        (provide-theme ',theme-name))))
 
-(defun load-into-load-path ()
-  (when load-file-name
-    (add-to-list 'custom-theme-load-path
-                 (file-name-as-directory (file-name-directory load-file-name)))))
+;;;###autoload
+(when (boundp 'custom-theme-load-path)
+  (add-to-list 'custom-theme-load-path
+               (file-name-as-directory (file-name-directory load-file-name))))
 
 (provide 'solarized-definitions)

--- a/solarized-light-theme.el
+++ b/solarized-light-theme.el
@@ -2,6 +2,4 @@
          (locate-file "solarized-definitions.el" custom-theme-load-path
                       '("c" "")))
 
-(load-into-load-path)
-
 (create-solarized-theme light)


### PR DESCRIPTION
solution that was proposed in https://github.com/sellout/emacs-color-theme-solarized/pull/47 doesn't work with my Emacs 24

I copied code from https://github.com/purcell/color-theme-sanityinc-solarized/blob/master/color-theme-sanityinc-solarized.el
