### PR TITLE
fix widget borders

### DIFF
--- a/solarized-definitions.el
+++ b/solarized-definitions.el
@@ -335,7 +335,7 @@ the \"Gen RGB\" column in solarized-definitions.el to improve them further."
              (show-paren-mismatch ((t (,@fmt-bold ,@fg-red ,@bg-base01))))
              ;; widgets
              (widget-field
-              ((t (,@fg-base1 ,@bg-base02 :box (:line-width 1 :color ,base2)
+              ((t (,@fg-base1 ,@bg-base02 :box (:line-width 1 @bg-base02)
                               :inherit default))))
              (widget-single-line-field ((t (:inherit widget-field))))
              ;; extra modules


### PR DESCRIPTION
borders on field widgets are exceptionnally bright. too bright. the attached commit fixes this.
