### PR TITLE
Font-latex and flyspell

### DIFF
--- a/solarized-definitions.el
+++ b/solarized-definitions.el
@@ -488,6 +488,12 @@ the \"Gen RGB\" column in solarized-definitions.el to improve them further."
              (rcirc-bright-nick ((t (:foreground ,magenta))))
              (rcirc-server ((t (:foreground ,base1))))
              (rcirc-timestamp ((t (:foreground ,base01)))))
+             ;;font-latex
+             (font-latex-warning-face ((t (,@fg-red))))
+             (font-latex-sectioning-5-face ((t (,@fg-violet))))
+             ;;flyspell
+             (flyspell-incorrect ((t (,@fg-red))))
+             (flyspell-duplicate ((t (,@fg-yellow))))
 
             ((foreground-color . ,(when (<= 16 (display-color-cells)) base0))
              (background-color . ,back)


### PR DESCRIPTION
Hi.
I guess font-latex inherits most of it's faces from more general definitions but a few were lacking so I added definitions for those.
I also added definitions for flyspell.
I'm not sure if I have done it completely right but it seems to work well for me anyway (adding only the right foreground color and while the other properties are inherited from standard values).
