### PR TITLE
Add colors for speedbar

### DIFF
--- a/solarized-definitions.el
+++ b/solarized-definitions.el
@@ -330,6 +330,14 @@ the \"Gen RGB\" column in solarized-definitions.el to improve them further."
              (outline-6 ((t (,@fmt-none ,@fg-base01))))
              (outline-7 ((t (,@fmt-none ,@fg-orange))))
              (outline-8 ((t (,@fmt-none ,@fg-violet))))
+             ;; speedbar
+             (speedbar-button-face ((t (,@fmt-none ,@fg-base1))))
+             (speedbar-directory-face ((t (,@fmt-none ,@fg-orange))))
+             (speedbar-file-face ((t (,@fmt-none ,@fg-green))))
+             (speedbar-highlight-face ((t (,@bg-base02))))
+             (speedbar-selected-face ((t (,@fmt-undr ,@fg-yellow))))
+             (speedbar-separator-face ((t (,@fmt-stnd))))
+             (speedbar-tag-face ((t (,@fmt-none ,@fg-blue))))
              ;; show-paren - MatchParen
              (show-paren-match ((t (,@fmt-bold ,@fg-cyan ,@bg-base02))))
              (show-paren-mismatch ((t (,@fmt-bold ,@fg-red ,@bg-base01))))


### PR DESCRIPTION
`emacs-color-theme-solarized' does not set colors for speedbar, so the speedbar does not match the rest of the interface.  This commit fixes the issue.
