### PR TITLE
Fix cell colors for built-in tables

### DIFF
--- a/solarized-definitions.el
+++ b/solarized-definitions.el
@@ -321,6 +321,8 @@ the \"Gen RGB\" column in solarized-definitions.el to improve them further."
              (org-started-kwd-face ((t (,@fg-yellow ,@bg-base03))))
              (org-cancelled-kwd-face ((t (,@fg-green ,@bg-base03))))
              (org-delegated-kwd-face ((t (,@fg-cyan ,@bg-base03))))
+             ;; table
+             (table-cell ((t (,@fmt-none ,@fg-base0 ,@bg-back))))
              ;; outline - pandocBlockQuoteLeader*
              (outline-1 ((t (,@fmt-none ,@fg-blue))))
              (outline-2 ((t (,@fmt-none ,@fg-cyan))))


### PR DESCRIPTION
Before this fix, tables created by 'table-insert' or 'table-capture'
have cells with a blue background and white foreground.  This fix makes
them blend in with the rest of 'emacs-color-theme-solarized'.
