### PR TITLE
the sRGB fix is not necessary for Mac build 3.2+, also post Mountain Lion? (need confirmation)

### DIFF
--- a/solarized-definitions.el
+++ b/solarized-definitions.el
@@ -40,7 +40,10 @@ down in order to expand or compress the tonal range displayed."
   :options '(high normal low)
   :group 'solarized)
 
-(defcustom solarized-broken-srgb (if (eq system-type 'darwin) t nil)
+(defcustom solarized-broken-srgb (if (and (eq system-type 'darwin)
+                                          (eq window-system 'ns))
+                                     t
+                                   nil)
   "Emacs bug #8402 results in incorrect color handling on Macs. If this is t
 \(the default on Macs), Solarized works around it with alternative colors.
 However, these colors are not totally portable, so you may be able to edit


### PR DESCRIPTION
remove sRGB color fix for mac build
- in version 3.2 of Mac port, this fix is not necessary
