### PR TITLE
Add support for ERC

### DIFF
--- a/solarized-definitions.el
+++ b/solarized-definitions.el
@@ -504,7 +504,7 @@ the \"Gen RGB\" column in solarized-definitions.el to improve them further."
              (rcirc-timestamp ((t (:foreground ,base01))))
              ;; ERC
              (erc-input-face ((t (:foreground ,base01))))
-             (erc-keyword-face ((t (,@fmt-bold ,@fg-cyan ,@bg-base02))))
+             (erc-keyword-face ((t (,@fmt-bldi ,@fg-yellow))))
              (erc-my-nick-face ((t (:foreground ,blue))))
              (erc-nick-default-face ((t (,@fmt-none ,@fg-cyan))))
              (erc-notice-face ((t (,@fmt-none ,@fg-blue))))


### PR DESCRIPTION
- User input is faded in order to focus on messages by others
- Keywords are same color as matched parens
- Nicks of others are unbolded cyan
- Server notices are unbolded blue
- Timestamps are faded, not bright

Looks best with the solarized-dark theme.
