### PR TITLE
Better handling of emacsclient, updated

### DIFF
--- a/solarized-definitions.el
+++ b/solarized-definitions.el
@@ -27,7 +27,7 @@ Ported to Emacs by Greg Pfeil, http://ethanschoonover.com/solarized.")
   :group 'solarized)
 
 (defcustom solarized-terminal-themed t
-  "Non-nil when the terminal emulator has been themes with Solarized.
+  "Non-nil when the terminal emulator has been themed with Solarized.
 In this scenario, we do not set the background color, in favor of the more
 accurate version of the color in the default terminal background."
   :type 'boolean
@@ -84,12 +84,14 @@ the \"Gen RGB\" column in solarized-definitions.el to improve them further."
     (dolist (property '(:foreground :background :color))
       (let ((color (plist-get new-fontspec property)))
         (when color
-          (if (and solarized-terminal-themed
-                   (or (and (eq property :background) (memq color back))
-                       (and (eq property :foreground) (memq color fg))))
-              (plist-put new-fontspec property nil)
-            (plist-put new-fontspec property
-                       (nth index (assoc color solarized-colors)))))))
+          (cond ((and solarized-terminal-themed
+                      (eq property :background) (memq color back))
+                 (plist-put new-fontspec property "unspecified-bg"))
+                ((and solarized-terminal-themed
+                      (eq property :foreground) (memq color fg))
+                 (plist-put new-fontspec property "unspecified-fg"))
+                (t (plist-put new-fontspec property
+                              (nth index (assoc color solarized-colors))))))))
     (when (plist-get new-fontspec :box)
       (plist-put new-fontspec :box (solarized-face-for-index
                                     (plist-get new-fontspec :box) index)))
@@ -192,345 +194,346 @@ the \"Gen RGB\" column in solarized-definitions.el to improve them further."
          (fmt-revbbu  `(:weight ,bright-bold :slant normal  :underline ,underline :inverse-video t)))
     (list
      ;; First list is for faces
-     (append
-      (solarized-faces `(,back) '(base0 base1)
-       `(;; basic
-         (default (,@fg-base0 ,@bg-back)) ; Normal
-         (cursor (,@fg-base03 ,@bg-base0)) ; Cursor
-         (error (,@fmt-bold ,@fg-red)) ; Error
-         (escape-glyph-face (,@fg-red))
-         (fringe (,@fg-base01 ,@bg-base02))
-         (linum (,@fg-base01 ,@bg-base02))
-         (header-line (,@fg-base0 ,@bg-base02 ,@fmt-revbb)) ; Pmenu
-         (highlight (,@bg-base02))
-         (hl-line (:underline ,opt-under ,@bg-base02)) ; CursorLine
-         (isearch (,@fmt-stnd ,@fg-orange ,@bg-back)) ; IncSearch
-         (isearch-fail (,@fmt-stnd ,@fg-orange ,@bg-back)) ; IncSearch
-         (lazy-highlight (,@fmt-revr ,@fg-yellow ,@bg-back)) ; Search
-         (link (,@fmt-undr ,@fg-violet))
-         (link-visited (,@fmt-undr ,@fg-magenta))
-         (menu (,@fg-base0 ,@bg-base02))
-         (minibuffer-prompt (,@fmt-bold ,@fg-cyan)) ; Question
-         (mode-line  ; StatusLine
-          (,@fg-base1 ,@bg-base02 ,@fmt-revbb :box nil))
-         (mode-line-inactive ; StatusLineNC
-          (,@fg-base00 ,@bg-base02 ,@fmt-revbb :box nil))
-         (region (,@fg-base01 ,@bg-base03 ,@fmt-revbb)) ; Visual
-         (secondary-selection (,@bg-base02))
-         (shadow (,@fg-base01))
-         (trailing-whitespace (,@fmt-revr ,@fg-red))
-         (vertical-border (,@fg-base0))
-         ;; comint
-         (comint-highlight-prompt (,@fg-blue))
-         ;; compilation
-         (compilation-info (,@fmt-bold ,@fg-green))
-         (compilation-warning (,@fmt-bold ,@fg-orange))
-         ;; custom
-         (custom-button
-          (,@fg-base1 ,@bg-base02
-                          :box (:line-width 2 :style released-button)))
-         (custom-button-mouse
-          (,@fmt-revr ,@fg-base1 ,@bg-base02 :inherit custom-button))
-         (custom-button-pressed
-          (,@fmt-revr ,@fg-base1 ,@bg-base02
-                          :box (:line-width 2 :style pressed-button)
-                          :inherit custom-button-mouse))
-         (custom-changed (,@fmt-revr ,@fg-blue ,@bg-base3))
-         (custom-comment (,@fg-base1 ,@bg-base02))
-         (custom-comment-tag (,@fg-base1 ,@bg-base02))
-         (custom-documentation (:inherit default))
-         (custom-group-tag (,@fg-base1))
-         (custom-group-tag-1 (,fmt-bold ,@fg-base1))
-         (custom-invalid (,@fmt-revr ,@fg-red ,@bg-back))
-         (custom-link (,@fg-violet))
-         (custom-state (,@fg-green))
-         (custom-variable-tag (,@fg-base1))
-         ;; diff - DiffAdd, DiffChange, DiffDelete, and DiffText
-         ,@(case solarized-diff-mode
-             (high
-              `((diff-added (,@fmt-revr ,@fg-green))
-                (diff-changed (,@fmt-revr ,@fg-yellow))
-                (diff-removed (,@fmt-revr ,@fg-red))
-                (diff-refine-change
-                 (,@fmt-revr ,@fg-blue ,@bg-back))))
-             (low
-              `((diff-added (,@fmt-undr ,@fg-green))
-                (diff-changed (,@fmt-undr ,@fg-yellow))
-                (diff-removed (,@fmt-bold ,@fg-red))
-                (diff-refine-change
-                 (,@fmt-undr ,@fg-blue ,@bg-back))))
-             (normal
-              (if window-system
-                  `((diff-added (,@fmt-bold ,@fg-green))
-                    (diff-changed (,@fmt-bold ,@fg-yellow))
-                    (diff-removed (,@fmt-bold ,@fg-red))
-                    (diff-refine-change
-                     (,@fmt-bold ,@fg-blue ,@bg-back)))
-                `((diff-added (,@fg-green))
-                  (diff-changed (,@fg-yellow))
-                  (diff-removed (,@fg-red))
-                  (diff-refine-change (,@fg-blue ,@bg-back))))))
-         (diff-file-header (,@bg-back))
-         (diff-header (,@fg-base1 ,@bg-back))
-         ;; IDO
-         (ido-only-match (,@fg-green))
-         (ido-subdir (,@fg-blue))
-         (ido-first-match (,@fmt-bold ,@fg-green))
-         ;; emacs-wiki
-         (emacs-wiki-bad-link-face (,@fmt-undr ,@fg-red))
-         (emacs-wiki-link-face (,@fmt-undr ,@fg-blue))
-         (emacs-wiki-verbatim-face (,@fmt-undr ,@fg-base00))
-         ;; eshell
-         (eshell-ls-archive (,@fg-magenta))
-         (eshell-ls-backup (,@fg-yellow))
-         (eshell-ls-clutter (,@fg-orange))
-         (eshell-ls-directory (,@fg-blue)) ; Directory
-         (eshell-ls-executable (,@fg-green))
-         (eshell-ls-missing (,@fg-red))
-         (eshell-ls-product (,@fg-yellow))
-         (eshell-ls-readonly (,@fg-base1))
-         (eshell-ls-special (,@fg-violet))
-         (eshell-ls-symlink (,@fg-cyan))
-         (eshell-ls-unreadable (,@fg-base00))
-         (eshell-prompt (,@fmt-bold ,@fg-green))
-         ;; font-lock
-         (font-lock-builtin-face (,@fmt-none ,@fg-green)) ; Statement
-         (font-lock-comment-face (,@fmt-ital ,@fg-base01)) ; Comment
-         (font-lock-constant-face (,@fmt-none ,@fg-cyan)) ; Constant
-         (font-lock-function-name-face ; Identifier
-          (,@fmt-none ,@fg-blue))
-         (font-lock-keyword-face (,@fmt-none ,@fg-green)) ; Statement
-         (font-lock-string-face (,@fmt-none ,@fg-cyan)) ; Constant
-         (font-lock-type-face (,@fmt-none ,@fg-yellow)) ; Type
-         (font-lock-variable-name-face ; Identifier
-          (,@fmt-none ,@fg-blue))
-         (font-lock-warning-face (,@fmt-bold ,@fg-red)) ; Error
-         (font-lock-doc-face (,@fmt-ital ,@fg-base01)) ; Comment
-         (font-lock-doc-string-face  ; Comment (XEmacs-only)
-          (,@fmt-ital ,@fg-base01))
-         (font-lock-color-constant-face (,@fmt-none ,@fg-green))
-         (font-lock-comment-delimiter-face ; Comment
-          (,@fmt-ital ,@fg-base01))
-         (font-lock-preprocessor-face ; PreProc
-          (,@fmt-none ,@fg-orange))
-         (font-lock-reference-face (,@fmt-none ,@fg-cyan))
-         (font-lock-negation-char-face (,@fmt-none ,@fg-red))
-         (font-lock-other-type-face (,@fmt-ital ,@fg-blue))
-         (font-lock-regexp-grouping-construct
-          (,@fmt-none ,@fg-orange))
-         (font-lock-special-keyword-face ; Special
-          (,@fmt-none ,@fg-red))
-         (font-lock-exit-face (,@fmt-none ,@fg-red))
-         (font-lock-other-emphasized-face (,@fmt-bldi ,@fg-violet))
-         (font-lock-regexp-grouping-backslash
-          (,@fmt-none ,@fg-yellow))
-         ;; info
-         (info-xref (,@fmt-undr ,@fg-blue))
-         (info-xref-visited (,@fg-magenta :inherit info-xref))
-         ;; org
-         (org-hide (,@fg-base03))
-         (org-todo (,@fmt-bold ,@fg-base03 ,@bg-red))
-         (org-done (,@fmt-bold ,@fg-green))
-         (org-todo-kwd-face (,@fg-red ,@bg-base03))
-         (org-done-kwd-face (,@fg-green ,@bg-base03))
-         (org-project-kwd-face (,@fg-violet ,@bg-base03))
-         (org-waiting-kwd-face (,@fg-orange ,@bg-base03))
-         (org-someday-kwd-face (,@fg-blue ,@bg-base03))
-         (org-started-kwd-face (,@fg-yellow ,@bg-base03))
-         (org-cancelled-kwd-face (,@fg-green ,@bg-base03))
-         (org-delegated-kwd-face (,@fg-cyan ,@bg-base03))
-         ;; table
-         (table-cell (,@fmt-none ,@fg-base0 ,@bg-back))
-         ;; outline - pandocBlockQuoteLeader*
-         (outline-1 (,@fmt-none ,@fg-blue))
-         (outline-2 (,@fmt-none ,@fg-cyan))
-         (outline-3 (,@fmt-none ,@fg-yellow))
-         (outline-4 (,@fmt-none ,@fg-red))
-         (outline-5 (,@fmt-none ,@fg-base0))
-         (outline-6 (,@fmt-none ,@fg-base01))
-         (outline-7 (,@fmt-none ,@fg-orange))
-         (outline-8 (,@fmt-none ,@fg-violet))
-         ;; speedbar
-         (speedbar-button-face (,@fmt-none ,@fg-base1))
-         (speedbar-directory-face (,@fmt-none ,@fg-orange))
-         (speedbar-file-face (,@fmt-none ,@fg-green))
-         (speedbar-highlight-face (,@bg-base02))
-         (speedbar-selected-face (,@fmt-undr ,@fg-yellow))
-         (speedbar-separator-face (,@fmt-stnd))
-         (speedbar-tag-face (,@fmt-none ,@fg-blue))
-         ;; show-paren - MatchParen
-         (show-paren-match (,@fmt-bold ,@fg-cyan ,@bg-base02))
-         (show-paren-mismatch (,@fmt-bold ,@fg-red ,@bg-base01))
-         ;; widgets
-         (widget-field
-          (,@fg-base1 ,@bg-base02 :box (:line-width 1)
-                          :inherit default))
-         (widget-single-line-field (:inherit widget-field))
-         ;; extra modules
-         ;; -------------
-         ;; Flymake
-         (flymake-errline (,@fmt-revr ,@fg-red ,@bg-back)) ; ErrorMsg
-         (flymake-warnline ; WarningMsg
-          (,@fmt-bold ,@fg-red ,@bg-back))
-         ;; column-marker
-         (column-marker-1 (,@bg-base01))
-         (column-marker-2 (,@bg-cyan))
-         (column-marker-3 (,@bg-violet))
-         ;; jabber
-         (jabber-activity-face (,@fmt-bold ,@fg-red))
-         (jabber-activity-personal-face (,@fmt-bold ,@fg-blue))
-         (jabber-chat-error (,@fmt-bold ,@fg-red))
-         (jabber-chat-prompt-foreign (,@fmt-bold ,@fg-red))
-         (jabber-chat-prompt-local (,@fmt-bold ,@fg-blue))
-         (jabber-chat-prompt-system (,@fmt-bold ,@fg-green))
-         (jabber-chat-text-foreign (,@fg-base1))
-         (jabber-chat-text-local (,@fg-base0))
-         (jabber-chat-rare-time-face (,@fmt-undr ,@fg-green))
-         (jabber-roster-user-away (,@fmt-ital ,@fg-green))
-         (jabber-roster-user-chatty (,@fmt-bold ,@fg-orange))
-         (jabber-roster-user-dnd (,@fmt-ital ,@fg-red))
-         (jabber-roster-user-error (:weight light :slant italic ,@fg-red))
-         (jabber-roster-user-offline (,@fg-base01))
-         (jabber-roster-user-online (,@fmt-bold ,@fg-blue))
-         (jabber-roster-user-xa (,@fmt-ital ,@fg-magenta))
-         ;; gnus - these are taken from mutt, not VIM
-         (gnus-cite-1 (,@fmt-none ,@fg-blue)) ; quoted
-         (gnus-cite-2 (,@fmt-none ,@fg-cyan)) ; quoted1
-         (gnus-cite-3 (,@fmt-none ,@fg-yellow)) ; quoted2
-         (gnus-cite-4 (,@fmt-none ,@fg-red)) ; quoted3
-         (gnus-cite-5 (,@fmt-none ,@fg-orange)) ; quoted4
-         (gnus-cite-6 (,@fmt-none ,@fg-violet))
-         (gnus-cite-7 (,@fmt-none ,@fg-green))
-         (gnus-cite-8 (,@fmt-none ,@fg-magenta))
-         (gnus-cite-9 (,@fmt-none ,@fg-base00))
-         (gnus-cite-10 (,@fmt-none ,@fg-base01))
-         (gnus-cite-11 (,@fmt-none ,@fg-base02))
-         (gnus-group-mail-1 (,@fmt-bold ,@fg-base3))
-         (gnus-group-mail-1-empty (,@fg-base3))
-         (gnus-group-mail-2 (,@fmt-bold ,@fg-base2))
-         (gnus-group-mail-2-empty (,@fg-base2))
-         (gnus-group-mail-3 (,@fmt-bold ,@fg-magenta))
-         (gnus-group-mail-3-empty (,@fg-magenta))
-         (gnus-group-mail-low (,@fmt-bold ,@fg-base00))
-         (gnus-group-mail-low-empty (,@fg-base00))
-         (gnus-group-news-1 (,@fmt-bold ,@fg-base1))
-         (gnus-group-news-1-empty (,@fg-base1))
-         (gnus-group-news-2 (,@fmt-bold ,@fg-blue))
-         (gnus-group-news-2-empty (,@fg-blue))
-         (gnus-group-news-low (,@fmt-bold ,@fg-violet))
-         (gnus-group-news-low-empty (,@fg-violet))
-         (gnus-emphasis-highlight-words ; highlight
-          (,@fmt-none ,fg-yellow))
-         (gnus-header-content (,@fmt-none ,@fg-base01)) ; hdrdefault
-         (gnus-header-from (,@fmt-none ,@fg-base00)) ; header ^From
-         (gnus-header-name (,@fmt-none ,@fg-base01)) ; hdrdefault
-         (gnus-header-newsgroups ; hdrdefault
-          (,@fmt-none ,@fg-base02))
-         (gnus-header-subject ; header ^Subject
-          (,@fmt-none ,@fg-blue))
-         (gnus-server-agent (,@fmt-bold ,@fg-base3))
-         (gnus-server-closed (,@fmt-ital ,@fg-base1))
-         (gnus-server-denied (,@fmt-bold ,@fg-base2))
-         (gnus-server-offline (,@fmt-bold ,@fg-green))
-         (gnus-server-opened (,@fmt-bold ,@fg-cyan))
-         (gnus-signature (,@fmt-none ,@fg-base01)) ; signature
-         (gnus-splash (,@fg-base2))
-         (gnus-summary-cancelled ; deleted messages
-          (,@fmt-none ,@fg-red))
-         (gnus-summary-high-ancient
-          (,@fmt-bold :inherit gnus-summary-normal-ancient))
-         (gnus-summary-high-read
-          (,@fmt-bold :inherit gnus-summary-normal-read))
-         (gnus-summary-high-ticked
-          (,@fmt-bold :inherit gnus-summary-normal-ticked))
-         (gnus-summary-high-undownloaded
-          (,@fmt-bold :inherit gnus-summary-normal-undownloaded))
-         (gnus-summary-high-unread
-          (,@fmt-bold :inherit gnus-summary-normal-unread))
-         (gnus-summary-low-ancient
-          (,@fmt-ital :inherit gnus-summary-normal-ancient))
-         (gnus-summary-low-read
-          (,@fmt-ital :inherit gnus-summary-normal-ancient))
-         (gnus-summary-low-unread
-          (,@fmt-ital :inherit gnus-summary-normal-unread))
-         (gnus-summary-low-ticked
-          (,@fmt-ital :inherit gnus-summary-normal-ancient))
-         (gnus-summary-low-undownloaded
-          (,@fmt-ital :inherit gnus-summary-normal-ancient))
-         (gnus-summary-normal-ancient ; old messages
-          (,@fmt-none ,@fg-blue))
-         (gnus-summary-normal-read ; read messages
-          (,@fmt-none ,@fg-base01))
-         (gnus-summary-normal-ticked ; flagged
-          (,@fmt-none ,@fg-red))
-         (gnus-summary-normal-undownloaded (,@fmt-none ,@fg-base2))
-         (gnus-summary-normal-unread ; unread messages
-          (,@fmt-none ,@fg-blue))
-         (gnus-summary-selected ; indicator
-          (,@fmt-none ,@fg-base03 ,@bg-yellow))
-         ;; Message
-         (message-mml (,@fg-blue))
-         (message-cited-text (,@fg-base2))
-         (message-separator (,@fg-base3))
-         (message-header-xheader (,@fg-violet))
-         (message-header-name (,@fg-cyan))
-         (message-header-other (,@fg-red))
-         (message-header-newsgroups (,@fmt-bldi ,@fg-yellow))
-         (message-header-subject (,@fg-base00))
-         (message-header-cc (,@fmt-bold ,@fg-green))
-         (message-header-to (,@fmt-bold ,@fg-base1))
-         ;; parenface
-         (paren-face (,@fg-base01))
-         ;; rainbow-delimiters
-         (rainbow-delimiters-depth-1-face (,@fg-cyan))
-         (rainbow-delimiters-depth-2-face (,@fg-yellow))
-         (rainbow-delimiters-depth-3-face (,@fg-blue))
-         (rainbow-delimiters-depth-4-face (,@fg-red))
-         (rainbow-delimiters-depth-5-face (,@fg-green))
-         (rainbow-delimiters-depth-6-face (,@fg-blue))
-         (rainbow-delimiters-depth-7-face (,@fg-orange))
-         (rainbow-delimiters-depth-8-face (,@fg-magenta))
-         (rainbow-delimiters-depth-9-face (,@fg-base0))
-         ;; slime
-         (slime-error-face (,@fmt-revr ,@fg-red)) ; ErrorMsg
-         (slime-note-face (,@fg-yellow))
-         (slime-repl-inputted-output-face (,@fg-red))
-         (slime-repl-output-mouseover-face (:box (:color base3)))
-         (slime-style-warning-face (,@fmt-bold ,@fg-orange))
-         (slime-warning-face (,@fmt-bold ,@fg-red)) ; WarningMsg
-         ;; whitespace
-         (whitespace-empty (,@fg-red))
-         (whitespace-hspace (,@fg-orange))
-         (whitespace-indentation (,@fg-base02))
-         (whitespace-space (,@fg-base02))
-         (whitespace-space-after-tab (,@fg-cyan))
-         (whitespace-space-before-tab (,@fmt-bold ,@fg-red))
-         (whitespace-tab (,@fg-base02))
-         (whitespace-trailing (,@fmt-bold ,@fg-red ,@bg-base02))
-         (whitespace-highlight-face (,@fg-red ,@bg-blue))
-         (whitespace-line (,@fg-magenta ,@bg-base03))
-         ;; rcirc
-         (rcirc-my-nick (:foreground blue))
-         (rcirc-nick-in-message (:foreground orange))
-         (rcirc-other-nick (:foreground green))
-         (rcirc-prompt (:foreground yellow))
-         (rcirc-bright-nick (:foreground magenta))
-         (rcirc-server (:foreground base1))
-         (rcirc-timestamp (:foreground base01))
-         ;; ERC
-         (erc-input-face (:foreground base01))
-         (erc-keyword-face (,@fmt-bldi ,@fg-yellow))
-         (erc-my-nick-face (:foreground blue))
-         (erc-nick-default-face (,@fmt-none ,@fg-cyan))
-         (erc-notice-face (,@fmt-none ,@fg-blue))
-         (erc-timestamp-face (:foreground base01))
-         ;;font-latex
-         (font-latex-warning-face (,@fg-red))
-         (font-latex-sectioning-5-face (,@fg-violet))
-         ;;flyspell
-         (flyspell-incorrect (,@fg-red))
-         (flyspell-duplicate (,@fg-yellow)))
-       mode)))))
+     (solarized-faces `(,back) '(base0 base1)
+      `(;; basic
+        (default (,@fg-base0 ,@bg-back)) ; Normal
+        (cursor (,@fg-base03 ,@bg-base0)) ; Cursor
+        (error (,@fmt-bold ,@fg-red)) ; Error
+        (escape-glyph-face (,@fg-red))
+        (fringe (,@fg-base01 ,@bg-base02))
+        (linum (,@fg-base01 ,@bg-base02))
+        (header-line (,@fg-base0 ,@bg-base02 ,@fmt-revbb)) ; Pmenu
+        (highlight (,@bg-base02))
+        (hl-line (:underline ,opt-under ,@bg-base02)) ; CursorLine
+        (isearch (,@fmt-stnd ,@fg-orange ,@bg-back)) ; IncSearch
+        (isearch-fail (,@fmt-stnd ,@fg-orange ,@bg-back)) ; IncSearch
+        (lazy-highlight (,@fmt-revr ,@fg-yellow ,@bg-back)) ; Search
+        (link (,@fmt-undr ,@fg-violet))
+        (link-visited (,@fmt-undr ,@fg-magenta))
+        (menu (,@fg-base0 ,@bg-base02))
+        (minibuffer-prompt (,@fmt-bold ,@fg-cyan)) ; Question
+        (mode-line  ; StatusLine
+         (,@fg-base1 ,@bg-base02 ,@fmt-revbb :box nil))
+        (mode-line-inactive ; StatusLineNC
+         (,@fg-base00 ,@bg-base02 ,@fmt-revbb :box nil))
+        (region (,@fg-base01 ,@bg-base03 ,@fmt-revbb)) ; Visual
+        (secondary-selection (,@bg-base02))
+        (shadow (,@fg-base01))
+        (trailing-whitespace (,@fmt-revr ,@fg-red))
+        (vertical-border (,@fg-base0))
+        ;; comint
+        (comint-highlight-prompt (,@fg-blue))
+        ;; compilation
+        (compilation-info (,@fmt-bold ,@fg-green))
+        (compilation-warning (,@fmt-bold ,@fg-orange))
+        ;; custom
+        (custom-button
+         (,@fg-base1 ,@bg-base02
+                         :box (:line-width 2 :style released-button)))
+        (custom-button-mouse
+         (,@fmt-revr ,@fg-base1 ,@bg-base02 :inherit custom-button))
+        (custom-button-pressed
+         (,@fmt-revr ,@fg-base1 ,@bg-base02
+                         :box (:line-width 2 :style pressed-button)
+                         :inherit custom-button-mouse))
+        (custom-changed (,@fmt-revr ,@fg-blue ,@bg-base3))
+        (custom-comment (,@fg-base1 ,@bg-base02))
+        (custom-comment-tag (,@fg-base1 ,@bg-base02))
+        (custom-documentation (:inherit default))
+        (custom-group-tag (,@fg-base1))
+        (custom-group-tag-1 (,fmt-bold ,@fg-base1))
+        (custom-invalid (,@fmt-revr ,@fg-red ,@bg-back))
+        (custom-link (,@fg-violet))
+        (custom-state (,@fg-green))
+        (custom-variable-tag (,@fg-base1))
+        ;; diff - DiffAdd, DiffChange, DiffDelete, and DiffText
+        ,@(case solarized-diff-mode
+            (high
+             `((diff-added (,@fmt-revr ,@fg-green))
+               (diff-changed (,@fmt-revr ,@fg-yellow))
+               (diff-removed (,@fmt-revr ,@fg-red))
+               (diff-refine-change
+                (,@fmt-revr ,@fg-blue ,@bg-back))))
+            (low
+             `((diff-added (,@fmt-undr ,@fg-green))
+               (diff-changed (,@fmt-undr ,@fg-yellow))
+               (diff-removed (,@fmt-bold ,@fg-red))
+               (diff-refine-change
+                (,@fmt-undr ,@fg-blue ,@bg-back))))
+            (normal
+             (if window-system
+                 `((diff-added (,@fmt-bold ,@fg-green))
+                   (diff-changed (,@fmt-bold ,@fg-yellow))
+                   (diff-removed (,@fmt-bold ,@fg-red))
+                   (diff-refine-change
+                    (,@fmt-bold ,@fg-blue ,@bg-back)))
+               `((diff-added (,@fg-green))
+                 (diff-changed (,@fg-yellow))
+                 (diff-removed (,@fg-red))
+                 (diff-refine-change (,@fg-blue ,@bg-back))))))
+        (diff-file-header (,@bg-back))
+        (diff-header (,@fg-base1 ,@bg-back))
+        ;; IDO
+        (ido-only-match (,@fg-green))
+        (ido-subdir (,@fg-blue))
+        (ido-first-match (,@fmt-bold ,@fg-green))
+        ;; emacs-wiki
+        (emacs-wiki-bad-link-face (,@fmt-undr ,@fg-red))
+        (emacs-wiki-link-face (,@fmt-undr ,@fg-blue))
+        (emacs-wiki-verbatim-face (,@fmt-undr ,@fg-base00))
+        ;; eshell
+        (eshell-ls-archive (,@fg-magenta))
+        (eshell-ls-backup (,@fg-yellow))
+        (eshell-ls-clutter (,@fg-orange))
+        (eshell-ls-directory (,@fg-blue)) ; Directory
+        (eshell-ls-executable (,@fg-green))
+        (eshell-ls-missing (,@fg-red))
+        (eshell-ls-product (,@fg-yellow))
+        (eshell-ls-readonly (,@fg-base1))
+        (eshell-ls-special (,@fg-violet))
+        (eshell-ls-symlink (,@fg-cyan))
+        (eshell-ls-unreadable (,@fg-base00))
+        (eshell-prompt (,@fmt-bold ,@fg-green))
+        ;; font-lock
+        (font-lock-builtin-face (,@fmt-none ,@fg-green)) ; Statement
+        (font-lock-comment-face (,@fmt-ital ,@fg-base01)) ; Comment
+        (font-lock-constant-face (,@fmt-none ,@fg-cyan)) ; Constant
+        (font-lock-function-name-face ; Identifier
+         (,@fmt-none ,@fg-blue))
+        (font-lock-keyword-face (,@fmt-none ,@fg-green)) ; Statement
+        (font-lock-string-face (,@fmt-none ,@fg-cyan)) ; Constant
+        (font-lock-type-face (,@fmt-none ,@fg-yellow)) ; Type
+        (font-lock-variable-name-face ; Identifier
+         (,@fmt-none ,@fg-blue))
+        (font-lock-warning-face (,@fmt-bold ,@fg-red)) ; Error
+        (font-lock-doc-face (,@fmt-ital ,@fg-base01)) ; Comment
+        (font-lock-doc-string-face  ; Comment (XEmacs-only)
+         (,@fmt-ital ,@fg-base01))
+        (font-lock-color-constant-face (,@fmt-none ,@fg-green))
+        (font-lock-comment-delimiter-face ; Comment
+         (,@fmt-ital ,@fg-base01))
+        (font-lock-preprocessor-face ; PreProc
+         (,@fmt-none ,@fg-orange))
+        (font-lock-reference-face (,@fmt-none ,@fg-cyan))
+        (font-lock-negation-char-face (,@fmt-none ,@fg-red))
+        (font-lock-other-type-face (,@fmt-ital ,@fg-blue))
+        (font-lock-regexp-grouping-construct
+         (,@fmt-none ,@fg-orange))
+        (font-lock-special-keyword-face ; Special
+         (,@fmt-none ,@fg-red))
+        (font-lock-exit-face (,@fmt-none ,@fg-red))
+        (font-lock-other-emphasized-face (,@fmt-bldi ,@fg-violet))
+        (font-lock-regexp-grouping-backslash
+         (,@fmt-none ,@fg-yellow))
+        ;; info
+        (info-xref (,@fmt-undr ,@fg-blue))
+        (info-xref-visited (,@fg-magenta :inherit info-xref))
+        ;; org
+        (org-hide (,@fg-base03))
+        (org-todo (,@fmt-bold ,@fg-base03 ,@bg-red))
+        (org-done (,@fmt-bold ,@fg-green))
+        (org-todo-kwd-face (,@fg-red ,@bg-base03))
+        (org-done-kwd-face (,@fg-green ,@bg-base03))
+        (org-project-kwd-face (,@fg-violet ,@bg-base03))
+        (org-waiting-kwd-face (,@fg-orange ,@bg-base03))
+        (org-someday-kwd-face (,@fg-blue ,@bg-base03))
+        (org-started-kwd-face (,@fg-yellow ,@bg-base03))
+        (org-cancelled-kwd-face (,@fg-green ,@bg-base03))
+        (org-delegated-kwd-face (,@fg-cyan ,@bg-base03))
+        ;; table
+        (table-cell (,@fmt-none ,@fg-base0 ,@bg-back))
+        ;; outline - pandocBlockQuoteLeader*
+        (outline-1 (,@fmt-none ,@fg-blue))
+        (outline-2 (,@fmt-none ,@fg-cyan))
+        (outline-3 (,@fmt-none ,@fg-yellow))
+        (outline-4 (,@fmt-none ,@fg-red))
+        (outline-5 (,@fmt-none ,@fg-base0))
+        (outline-6 (,@fmt-none ,@fg-base01))
+        (outline-7 (,@fmt-none ,@fg-orange))
+        (outline-8 (,@fmt-none ,@fg-violet))
+        ;; speedbar
+        (speedbar-button-face (,@fmt-none ,@fg-base1))
+        (speedbar-directory-face (,@fmt-none ,@fg-orange))
+        (speedbar-file-face (,@fmt-none ,@fg-green))
+        (speedbar-highlight-face (,@bg-base02))
+        (speedbar-selected-face (,@fmt-undr ,@fg-yellow))
+        (speedbar-separator-face (,@fmt-stnd))
+        (speedbar-tag-face (,@fmt-none ,@fg-blue))
+        ;; show-paren - MatchParen
+        (show-paren-match (,@fmt-bold ,@fg-cyan ,@bg-base02))
+        (show-paren-mismatch (,@fmt-bold ,@fg-red ,@bg-base01))
+        ;; widgets
+        (widget-field
+         (,@fg-base1 ,@bg-base02 :box (:line-width 1)
+                         :inherit default))
+        (widget-single-line-field (:inherit widget-field))
+        ;; extra modules
+        ;; -------------
+        ;; Flymake
+        (flymake-errline (,@fmt-revr ,@fg-red ,@bg-back)) ; ErrorMsg
+        (flymake-warnline ; WarningMsg
+         (,@fmt-bold ,@fg-red ,@bg-back))
+        ;; column-marker
+        (column-marker-1 (,@bg-base01))
+        (column-marker-2 (,@bg-cyan))
+        (column-marker-3 (,@bg-violet))
+        ;; jabber
+        (jabber-activity-face (,@fmt-bold ,@fg-red))
+        (jabber-activity-personal-face (,@fmt-bold ,@fg-blue))
+        (jabber-chat-error (,@fmt-bold ,@fg-red))
+        (jabber-chat-prompt-foreign (,@fmt-bold ,@fg-red))
+        (jabber-chat-prompt-local (,@fmt-bold ,@fg-blue))
+        (jabber-chat-prompt-system (,@fmt-bold ,@fg-green))
+        (jabber-chat-text-foreign (,@fg-base1))
+        (jabber-chat-text-local (,@fg-base0))
+        (jabber-chat-rare-time-face (,@fmt-undr ,@fg-green))
+        (jabber-roster-user-away (,@fmt-ital ,@fg-green))
+        (jabber-roster-user-chatty (,@fmt-bold ,@fg-orange))
+        (jabber-roster-user-dnd (,@fmt-ital ,@fg-red))
+        (jabber-roster-user-error (:weight light :slant italic ,@fg-red))
+        (jabber-roster-user-offline (,@fg-base01))
+        (jabber-roster-user-online (,@fmt-bold ,@fg-blue))
+        (jabber-roster-user-xa (,@fmt-ital ,@fg-magenta))
+        ;; gnus - these are taken from mutt, not VIM
+        (gnus-cite-1 (,@fmt-none ,@fg-blue)) ; quoted
+        (gnus-cite-2 (,@fmt-none ,@fg-cyan)) ; quoted1
+        (gnus-cite-3 (,@fmt-none ,@fg-yellow)) ; quoted2
+        (gnus-cite-4 (,@fmt-none ,@fg-red)) ; quoted3
+        (gnus-cite-5 (,@fmt-none ,@fg-orange)) ; quoted4
+        (gnus-cite-6 (,@fmt-none ,@fg-violet))
+        (gnus-cite-7 (,@fmt-none ,@fg-green))
+        (gnus-cite-8 (,@fmt-none ,@fg-magenta))
+        (gnus-cite-9 (,@fmt-none ,@fg-base00))
+        (gnus-cite-10 (,@fmt-none ,@fg-base01))
+        (gnus-cite-11 (,@fmt-none ,@fg-base02))
+        (gnus-group-mail-1 (,@fmt-bold ,@fg-base3))
+        (gnus-group-mail-1-empty (,@fg-base3))
+        (gnus-group-mail-2 (,@fmt-bold ,@fg-base2))
+        (gnus-group-mail-2-empty (,@fg-base2))
+        (gnus-group-mail-3 (,@fmt-bold ,@fg-magenta))
+        (gnus-group-mail-3-empty (,@fg-magenta))
+        (gnus-group-mail-low (,@fmt-bold ,@fg-base00))
+        (gnus-group-mail-low-empty (,@fg-base00))
+        (gnus-group-news-1 (,@fmt-bold ,@fg-base1))
+        (gnus-group-news-1-empty (,@fg-base1))
+        (gnus-group-news-2 (,@fmt-bold ,@fg-blue))
+        (gnus-group-news-2-empty (,@fg-blue))
+        (gnus-group-news-low (,@fmt-bold ,@fg-violet))
+        (gnus-group-news-low-empty (,@fg-violet))
+        (gnus-emphasis-highlight-words ; highlight
+         (,@fmt-none ,fg-yellow))
+        (gnus-header-content (,@fmt-none ,@fg-base01)) ; hdrdefault
+        (gnus-header-from (,@fmt-none ,@fg-base00)) ; header ^From
+        (gnus-header-name (,@fmt-none ,@fg-base01)) ; hdrdefault
+        (gnus-header-newsgroups ; hdrdefault
+         (,@fmt-none ,@fg-base02))
+        (gnus-header-subject ; header ^Subject
+         (,@fmt-none ,@fg-blue))
+        (gnus-server-agent (,@fmt-bold ,@fg-base3))
+        (gnus-server-closed (,@fmt-ital ,@fg-base1))
+        (gnus-server-denied (,@fmt-bold ,@fg-base2))
+        (gnus-server-offline (,@fmt-bold ,@fg-green))
+        (gnus-server-opened (,@fmt-bold ,@fg-cyan))
+        (gnus-signature (,@fmt-none ,@fg-base01)) ; signature
+        (gnus-splash (,@fg-base2))
+        (gnus-summary-cancelled ; deleted messages
+         (,@fmt-none ,@fg-red))
+        (gnus-summary-high-ancient
+         (,@fmt-bold :inherit gnus-summary-normal-ancient))
+        (gnus-summary-high-read
+         (,@fmt-bold :inherit gnus-summary-normal-read))
+        (gnus-summary-high-ticked
+         (,@fmt-bold :inherit gnus-summary-normal-ticked))
+        (gnus-summary-high-undownloaded
+         (,@fmt-bold :inherit gnus-summary-normal-undownloaded))
+        (gnus-summary-high-unread
+         (,@fmt-bold :inherit gnus-summary-normal-unread))
+        (gnus-summary-low-ancient
+         (,@fmt-ital :inherit gnus-summary-normal-ancient))
+        (gnus-summary-low-read
+         (,@fmt-ital :inherit gnus-summary-normal-ancient))
+        (gnus-summary-low-unread
+         (,@fmt-ital :inherit gnus-summary-normal-unread))
+        (gnus-summary-low-ticked
+         (,@fmt-ital :inherit gnus-summary-normal-ancient))
+        (gnus-summary-low-undownloaded
+         (,@fmt-ital :inherit gnus-summary-normal-ancient))
+        (gnus-summary-normal-ancient ; old messages
+         (,@fmt-none ,@fg-blue))
+        (gnus-summary-normal-read ; read messages
+         (,@fmt-none ,@fg-base01))
+        (gnus-summary-normal-ticked ; flagged
+         (,@fmt-none ,@fg-red))
+        (gnus-summary-normal-undownloaded (,@fmt-none ,@fg-base2))
+        (gnus-summary-normal-unread ; unread messages
+         (,@fmt-none ,@fg-blue))
+        (gnus-summary-selected ; indicator
+         (,@fmt-none ,@fg-base03 ,@bg-yellow))
+        ;; Message
+        (message-mml (,@fg-blue))
+        (message-cited-text (,@fg-base2))
+        (message-separator (,@fg-base3))
+        (message-header-xheader (,@fg-violet))
+        (message-header-name (,@fg-cyan))
+        (message-header-other (,@fg-red))
+        (message-header-newsgroups (,@fmt-bldi ,@fg-yellow))
+        (message-header-subject (,@fg-base00))
+        (message-header-cc (,@fmt-bold ,@fg-green))
+        (message-header-to (,@fmt-bold ,@fg-base1))
+        ;; parenface
+        (paren-face (,@fg-base01))
+        ;; rainbow-delimiters
+        (rainbow-delimiters-depth-1-face (,@fg-cyan))
+        (rainbow-delimiters-depth-2-face (,@fg-yellow))
+        (rainbow-delimiters-depth-3-face (,@fg-blue))
+        (rainbow-delimiters-depth-4-face (,@fg-red))
+        (rainbow-delimiters-depth-5-face (,@fg-green))
+        (rainbow-delimiters-depth-6-face (,@fg-blue))
+        (rainbow-delimiters-depth-7-face (,@fg-orange))
+        (rainbow-delimiters-depth-8-face (,@fg-magenta))
+        (rainbow-delimiters-depth-9-face (,@fg-base0))
+        ;; slime
+        (slime-error-face (,@fmt-revr ,@fg-red)) ; ErrorMsg
+        (slime-note-face (,@fg-yellow))
+        (slime-repl-inputted-output-face (,@fg-red))
+        (slime-repl-output-mouseover-face (:box (:color base3)))
+        (slime-style-warning-face (,@fmt-bold ,@fg-orange))
+        (slime-warning-face (,@fmt-bold ,@fg-red)) ; WarningMsg
+        ;; whitespace
+        (whitespace-empty (,@fg-red))
+        (whitespace-hspace (,@fg-orange))
+        (whitespace-indentation (,@fg-base02))
+        (whitespace-space (,@fg-base02))
+        (whitespace-space-after-tab (,@fg-cyan))
+        (whitespace-space-before-tab (,@fmt-bold ,@fg-red))
+        (whitespace-tab (,@fg-base02))
+        (whitespace-trailing (,@fmt-bold ,@fg-red ,@bg-base02))
+        (whitespace-highlight-face (,@fg-red ,@bg-blue))
+        (whitespace-line (,@fg-magenta ,@bg-base03))
+        ;; rcirc
+        (rcirc-my-nick (:foreground blue))
+        (rcirc-nick-in-message (:foreground orange))
+        (rcirc-other-nick (:foreground green))
+        (rcirc-prompt (:foreground yellow))
+        (rcirc-bright-nick (:foreground magenta))
+        (rcirc-server (:foreground base1))
+        (rcirc-timestamp (:foreground base01))
+        ;; ERC
+        (erc-input-face (:foreground base01))
+        (erc-keyword-face (,@fmt-bldi ,@fg-yellow))
+        (erc-my-nick-face (:foreground blue))
+        (erc-nick-default-face (,@fmt-none ,@fg-cyan))
+        (erc-notice-face (,@fmt-none ,@fg-blue))
+        (erc-timestamp-face (:foreground base01))
+        ;;font-latex
+        (font-latex-warning-face (,@fg-red))
+        (font-latex-sectioning-5-face (,@fg-violet))
+        ;;flyspell
+        (flyspell-incorrect (,@fg-red))
+        (flyspell-duplicate (,@fg-yellow)))
+      mode)
+     ;; Second list is for vars
+     `((background-mode . ,mode)))))
 
 (defmacro create-solarized-theme (mode)
   (let* ((theme-name (intern (concat "solarized-" (symbol-name mode))))


### PR DESCRIPTION
I've taken @ahyatt's changes from https://github.com/sellout/emacs-color-theme-solarized/pull/17 and have applied them to my branch, with some updates.  Full list of changes:
- Remove solarized-degrade (from ahyatt)
- Put nil in 5th column of solarized-colors for base00 and base0 so that they don't change in 8-color mode
- New function solarized-face-for-index (from ahyatt)
- New function solariezd-flip (from ahyatt)
- New function solarized-faces (from ahyatt)
  - Vary color for different terms in face specs only (from ahyatt)
  - Reverse light/dark logic to match upstream
  - Add support for 8-color terms
  - Support solarized-broken-srgb
- solarized-color-definitions: Start with faces from upstream and apply ahyatt's changes:
  - Replace light case with generic URL in documentation
  - Consolidate let-bound lists with let\* to reduce indentation
  - Don't let-bind yellow and other colors
  - Use default and cursor faces instead of having separate list of attributes to set them
  - Add bright-bold, opt-under, back
  - Base faces are symbols, not let-bound variables
  - Change ((t (spec))) to just (spec) throughout
- No attempt has been made to support the solarized-contrast high case due to lack of time.  Perhaps a 6th column in
  solarized-colors would be a better approach than rotatef on existing colors.
- No attempt is made to set background-mode; perhaps it is unnecessary since full face definitions are provided
