### PR TITLE
Dynamically generate appropriate ansi-term colors

### DIFF
--- a/solarized-definitions.el
+++ b/solarized-definitions.el
@@ -520,18 +520,22 @@ the \"Gen RGB\" column in solarized-definitions.el to improve them further."
              (background-color . ,back)
              (background-mode . ,mode)
              (cursor-color . ,(when (<= 16 (display-color-cells))
-                                base0)))))))))
+                                base0))
+             (ansi-term-color-vector . [unspecified ,base02 ,red ,green ,yellow ,blue ,magenta ,cyan ,base2]))))))))
 
 (defmacro create-solarized-theme (mode)
   (let* ((theme-name (intern (concat "solarized-" (symbol-name mode))))
          (defs (solarized-color-definitions mode))
          (theme-vars (mapcar (lambda (def) (list (car def) (cdr def)))
                              (second defs)))
-         (theme-faces (first defs)))
+         (theme-faces (first defs))
+         (ansi-term-color-vector (remove-if-not (lambda (def) (eq (symbol-name (car def)) 'ansi-term-color-vector)) theme-vars)))
     `(progn
        (deftheme ,theme-name ,solarized-description)
        (apply 'custom-theme-set-variables ',theme-name ',theme-vars)
        (apply 'custom-theme-set-faces ',theme-name ',theme-faces)
+       (eval-after-load 'term
+         (setq ansi-term-color-vector ,ansi-term-color-vector))
        (provide-theme ',theme-name))))
 
 ;;;###autoload


### PR DESCRIPTION
When an `ansi-term` buffer is launched, it gets the standard ANSI colours.

This can be overridden by explicitly setting `ansi-term-color-vector` when `term` is loaded. This replaces the standard 8 ANSI colours with the colours from the vector passed in.

I have two concerns with this commit:
1. The code isn't great - really the fetching/naming of colours wants to be factored out instead of being generated in a giant `flet/let` construct. This way the vector could be generated outside the main construct;
2. I'm not sure completely clobbering `ansi-term-color-vector` is the best thing to do, but it's what [other themes](https://github.com/bbatsov/zenburn-emacs/blob/3672f48b8b8dad7521ef1f4b075a327e735e03f0/zenburn-theme.el#L583) do.
