### PR TITLE
Use solarized colors for shell-mode and term-mode

### DIFF
--- a/solarized-definitions.el
+++ b/solarized-definitions.el
@@ -514,13 +514,23 @@ the \"Gen RGB\" column in solarized-definitions.el to improve them further."
              (font-latex-sectioning-5-face ((t (,@fg-violet))))
              ;;flyspell
              (flyspell-incorrect ((t (,@fg-red))))
-             (flyspell-duplicate ((t (,@fg-yellow)))))
+             (flyspell-duplicate ((t (,@fg-yellow))))
+	     ;;ansi-term
+	     (term-color-black ((t ( ,@fg-base02))))
+	     (term-color-red ((t ( ,@fg-red))))
+	     (term-color-green ((t ( ,@fg-green))))
+	     (term-color-yellow ((t ( ,@fg-yellow))))
+	     (term-color-blue ((t ( ,@fg-blue))))
+	     (term-color-magenta ((t ( ,@fg-magenta))))
+	     (term-color-cyan ((t ( ,@fg-cyan))))
+	     (term-color-white ((t ( ,@fg-base00)))))
 
             ((foreground-color . ,(when (<= 16 (display-color-cells)) base0))
              (background-color . ,back)
              (background-mode . ,mode)
              (cursor-color . ,(when (<= 16 (display-color-cells))
-                                base0)))))))))
+                                base0))
+	     (ansi-color-names-vector . [,base02 ,red ,green ,yellow ,blue ,magenta ,cyan ,base00]))))))))
 
 (defmacro create-solarized-theme (mode)
   (let* ((theme-name (intern (concat "solarized-" (symbol-name mode))))


### PR DESCRIPTION
Originally, the theme doesn't apply to the colors in shell-mode or in term-mode.  This commit adds solarized color definitions for term-mode, and defines a solarized ansi-color-names-vector for setting colors in shell-mode.

Note: colors for term-mode only work for (to be released) emacs 24.3 and later.
