### PR TITLE
Add background variants for term-color-*

### DIFF
--- a/solarized-definitions.el
+++ b/solarized-definitions.el
@@ -143,7 +143,7 @@ the \"Gen RGB\" column in solarized-definitions.el to improve them further."
               (bg-violet `(:background ,violet))
               (bg-blue `(:background ,blue))
               (bg-cyan `(:background ,cyan))
-              
+
               (fg-base03 `(:foreground ,base03))
               (fg-base02 `(:foreground ,base02))
               (fg-base01 `(:foreground ,base01))
@@ -523,14 +523,14 @@ the \"Gen RGB\" column in solarized-definitions.el to improve them further."
              (flyspell-incorrect ((t (,@fg-red))))
              (flyspell-duplicate ((t (,@fg-yellow))))
 	     ;;ansi-term
-	     (term-color-black ((t ( ,@fg-base02))))
-	     (term-color-red ((t ( ,@fg-red))))
-	     (term-color-green ((t ( ,@fg-green))))
-	     (term-color-yellow ((t ( ,@fg-yellow))))
-	     (term-color-blue ((t ( ,@fg-blue))))
-	     (term-color-magenta ((t ( ,@fg-magenta))))
-	     (term-color-cyan ((t ( ,@fg-cyan))))
-	     (term-color-white ((t ( ,@fg-base00)))))
+	     (term-color-black ((t ( ,@fg-base02 ,@bg-base02))))
+	     (term-color-red ((t ( ,@fg-red ,@bg-red))))
+	     (term-color-green ((t ( ,@fg-green ,@bg-green))))
+	     (term-color-yellow ((t ( ,@fg-yellow ,@bg-yellow))))
+	     (term-color-blue ((t ( ,@fg-blue ,@bg-blue))))
+	     (term-color-magenta ((t ( ,@fg-magenta ,@bg-magenta))))
+	     (term-color-cyan ((t ( ,@fg-cyan ,@bg-cyan))))
+	     (term-color-white ((t ( ,@fg-base00 ,@bg-base00)))))
 
             ((foreground-color . ,(when (<= 16 (display-color-cells)) base0))
              (background-color . ,back)


### PR DESCRIPTION
These have defaults which don't look right in ansi-term etc.

They're also safe to overwrite the background color of because each variant applies to the ANSI equivalent of background/foreground, e.g text won't suddenly become entirely orange.

Without this change you get yellow background like the one seen on `master`:

![Screen Shot 2013-03-31 at 19 40 28](https://f.cloud.github.com/assets/1516/322216/7e47da86-9a32-11e2-97f9-fb47eda5d13f.png)

Prior to this change running `M-x describe-face term-color-yellow` shows the following:

```
Face: term-color-yellow (sample) (customize this face)
...
Foreground: #a57705
Background: yellow3
```
