### PR TITLE
fix modeline and field borders

### DIFF
--- a/solarized-definitions.el
+++ b/solarized-definitions.el
@@ -247,11 +247,9 @@ the \"Gen RGB\" column in solarized-definitions.el to improve them further."
                 (menu (,@fg-base0 ,@bg-base02))
                 (minibuffer-prompt (,@fmt-bold ,@fg-cyan)) ; Question
                 (mode-line ; StatusLine
-                 (,@fg-base03 ,@bg-base1 ,@fmt-revbb :box nil))
+                 (,@fg-base03 ,@bg-base01 ,@fmt-revbb :box nil))
                 (mode-line-inactive    ; StatusLineNC
-                 (,@fg-base03 ,@bg-base00 ,@fmt-revbb :box nil))
-                (mode-line-buffer-id
-                 ((t (,@fg-base03))))
+                 (,@fg-base03 ,@bg-base02 ,@fmt-revbb :box nil))
                 (region (,@fg-base01 ,@bg-base03 ,@fmt-revbb)) ; Visual
                 (secondary-selection (,@bg-base02))
                 (shadow (,@fg-base01))

--- a/solarized-definitions.el
+++ b/solarized-definitions.el
@@ -247,9 +247,11 @@ the \"Gen RGB\" column in solarized-definitions.el to improve them further."
                 (menu (,@fg-base0 ,@bg-base02))
                 (minibuffer-prompt (,@fmt-bold ,@fg-cyan)) ; Question
                 (mode-line ; StatusLine
-                 (,@fg-base1 ,@bg-base02 ,@fmt-revbb :box nil))
+                 (,@fg-base03 ,@bg-base1 ,@fmt-revbb :box nil))
                 (mode-line-inactive    ; StatusLineNC
-                 (,@fg-base00 ,@bg-base02 ,@fmt-revbb :box nil))
+                 (,@fg-base03 ,@bg-base00 ,@fmt-revbb :box nil))
+                (mode-line-buffer-id
+                 ((t (,@fg-base03))))
                 (region (,@fg-base01 ,@bg-base03 ,@fmt-revbb)) ; Visual
                 (secondary-selection (,@bg-base02))
                 (shadow (,@fg-base01))


### PR DESCRIPTION
the modeline somehow lost its background, and it is not in sync with the vi implementation. this fixes both problems. this is a port of [pull request 125](https://github.com/altercation/solarized/pull/125) on the solarized project itself.

we also remove borders on fields because it is quite annoying.