### PR TITLE
Add support for ‘match’ (used by Occur).

### DIFF
--- a/solarized-definitions.el
+++ b/solarized-definitions.el
@@ -199,6 +199,7 @@ the \"Gen RGB\" column in solarized-definitions.el to improve them further."
              (isearch ((t (,@fmt-stnd ,@fg-orange ,@bg-back)))) ; IncSearch
              (isearch-fail ((t (,@fmt-stnd ,@fg-orange ,@bg-back)))) ; IncSearch
              (lazy-highlight ((t (,@fmt-revr ,@fg-yellow ,@bg-back)))) ; Search
+             (match ((t (,@fmt-revr ,@fg-yellow ,@bg-back)))) ; Occur
              (link ((t (,@fmt-undr ,@fg-violet))))
              (link-visited ((t (,@fmt-undr ,@fg-magenta))))
              (menu ((t (,@fg-base0 ,@bg-base02))))


### PR DESCRIPTION
Color is background yellow, same as ‘lazy-highlight’.
