### PR TITLE
Changed `let*` to `let` on solarized-definitions.el

### DIFF
--- a/solarized-definitions.el
+++ b/solarized-definitions.el
@@ -86,7 +86,7 @@ the \"Gen RGB\" column in solarized-definitions.el to improve them further."
 
 (defun solarized-color-definitions (mode)
   (which-flet ((find-color (name)
-           (let* ((index (if window-system
+           (let ((index (if window-system
                              (if solarized-degrade
                                  3
                                (if solarized-broken-srgb 2 1))


### PR DESCRIPTION
Changed a `let*` to `let` on the `solarized-color-definitions` function.
Without this change, the entire definition of the inner function
`find-color` doesn't compile, with the message "Invalid function" from
emacs.

Tested on:
GNU Emacs 24.2.1 (i386-mingw-nt6.1.7601) of 2012-08-28 on MARVIN
