### PR TITLE
Fix which-flet logic

### DIFF
--- a/solarized-definitions.el
+++ b/solarized-definitions.el
@@ -79,7 +79,8 @@ the \"Gen RGB\" column in solarized-definitions.el to improve them further."
 (defvar which-flet
   "This variable will store either flet or cl-flet depending on the Emacs
   version. flet was deprecated in in 24.3")
-(if (and (> emacs-major-version 24) (> emacs-minor-version 2))
+(if (or (> emacs-major-version 24)
+        (and (>= emacs-major-version 24) (> emacs-minor-version 2)))
     (fset 'which-flet 'cl-flet)
   (fset 'which-flet 'flet))
 


### PR DESCRIPTION
flet was deprecated in 24.3, but daff304 accidentally used > 25.2 instead
of >= 24.3 as a condition. This commit fixes that.
