### PR TITLE
Define colors for ace-jump-mode

### DIFF
--- a/solarized-definitions.el
+++ b/solarized-definitions.el
@@ -363,6 +363,9 @@ the \"Gen RGB\" column in solarized-definitions.el to improve them further."
              (widget-single-line-field ((t (:inherit widget-field))))
              ;; extra modules
              ;; -------------
+	     ;; ace-jump-mode
+	     (ace-jump-face-background ((t (,@fmt-none ,@fg-base01))))
+	     (ace-jump-face-foreground ((t (,@fmt-bold ,@fg-red))))
 	     ;; bm visual bookmarks
 	     (bm-fringe-face ((t (,@bg-orange ,@fg-base03))))
 	     (bm-fringe-persistent-face ((t (,@bg-blue ,@fg-base03))))


### PR DESCRIPTION
I use fg-red and fg-base01 for the red and gray40, respectively, tht
ace-jump-mode.el uses:

https://github.com/winterTTr/ace-jump-mode/blob/07b7137/ace-jump-mode.el#L303
https://github.com/winterTTr/ace-jump-mode/blob/07b7137/ace-jump-mode.el#L297

The original Vim plugin also recommends red and comment (faded), which is
what the above accomplishes:

https://github.com/Lokaltog/vim-easymotion/blob/eaa4af/doc/easymotion.txt#L992
