### PR TITLE
Make 'which-flet' a macro.

### DIFF
--- a/solarized-definitions.el
+++ b/solarized-definitions.el
@@ -77,13 +77,15 @@ the \"Gen RGB\" column in solarized-definitions.el to improve them further."
    column is a different set, one of which will be chosen based on term
    capabilities, etc.")
 
-(defvar which-flet
-  "This variable will store either flet or cl-flet depending on the Emacs
-  version. flet was deprecated in in 24.3")
-(if (or (> emacs-major-version 24)
-        (and (>= emacs-major-version 24) (> emacs-minor-version 2)))
-    (fset 'which-flet 'cl-flet)
-  (fset 'which-flet 'flet))
+
+(defmacro which-flet (bindings &rest body)
+  "This macro will expand either to flet or cl-flet depending on
+the Emacs version. flet was deprecated in in 24.3"
+  (eval-when-compile
+    (if (or (> emacs-major-version 24)
+            (and (>= emacs-major-version 24) (> emacs-minor-version 2)))
+        `(cl-flet ,bindings ,@body)
+      `(flet ,bindings ,@body))))
 
 (defun solarized-color-definitions (mode)
   (which-flet ((find-color (name)


### PR DESCRIPTION
I started getting the `"Invalid function: (find-color ...."` error on Emacs 24.3.1 after an update and this change fixed it.