### PR TITLE
Add support for magit next

### DIFF
--- a/solarized-definitions.el
+++ b/solarized-definitions.el
@@ -548,6 +548,13 @@ the \"Gen RGB\" column in solarized-definitions.el to improve them further."
              ;;flyspell
              (flyspell-incorrect ((t (,@fg-red))))
              (flyspell-duplicate ((t (,@fg-yellow))))
+             ;; rst-mode
+             (rst-level-1 ((t (,@bg-base03 ,@fg-base1))))
+             (rst-level-2 ((t (,@bg-base03 ,@fg-base1))))
+             (rst-level-3 ((t (,@bg-base01 ,@fg-base02))))
+             (rst-level-4 ((t (,@bg-base01 ,@fg-base02))))
+             (rst-level-5 ((t (,@bg-base02 ,@fg-base01))))
+             (rst-level-6 ((t (,@bg-base02 ,@fg-base01))))
 	     ;;ansi-term
 	     (term-color-black ((t ( ,@fg-base02))))
 	     (term-color-red ((t ( ,@fg-red))))


### PR DESCRIPTION
This commit adds support for the forthcoming [next branch](https://github.com/magit/magit/tree/next) of magit, which should be
merged in master in the near future.
magit-next defined new faces for it's diff hunks that do not play well
with the solarized dark, and this commit intend to fix it.
