### PR TITLE
Add support for magit next

### DIFF
--- a/solarized-definitions.el
+++ b/solarized-definitions.el
@@ -548,6 +548,15 @@ the \"Gen RGB\" column in solarized-definitions.el to improve them further."
                 (slime-repl-output-mouseover-face (:box (:color base3)))
                 (slime-style-warning-face (,@fmt-bold ,@fg-orange))
                 (slime-warning-face (,@fmt-bold ,@fg-red)) ; WarningMsg
+                ;;magit next branch
+                (magit-diff-added (,@bg-back ,@fg-green))
+                (magit-diff-removed (,@bg-back ,@fg-red))
+                (magit-diff-context (,@bg-back ,@fg-base1))
+                (magit-diff-added-highlight (,@bg-base02 ,@fg-green))
+                (magit-diff-removed-highlight (,@bg-base02 ,@fg-red))
+                (magit-diff-context-highlight (,@bg-base02 ,@fg-base1))
+                (magit-hunk-heading (,@bg-base03 ,@fg-base1))
+                (magit-section-highlight (,@bg-base02))
                 ;; whitespace
                 (whitespace-empty (,@fg-red))
                 (whitespace-hspace (,@fg-orange))


### PR DESCRIPTION
This commit adds support for the forthcoming [next branch](https://github.com/magit/magit/tree/next) of magit, which should be
merged in master in the near future.
magit-next defined new faces for it's diff hunks that do not play well
with the solarized dark, and this commit intend to fix it.
