### PR TITLE
Fix theme "background-mode" variable definition

### DIFF
--- a/solarized-definitions.el
+++ b/solarized-definitions.el
@@ -551,7 +551,7 @@ the \"Gen RGB\" column in solarized-definitions.el to improve them further."
 
             ((foreground-color . ,(when (<= 16 (display-color-cells)) base0))
              (background-color . ,back)
-             (background-mode . ,mode)
+             (background-mode . ,(symbol-name mode))
              (cursor-color . ,(when (<= 16 (display-color-cells))
                                 base0))
 	     (ansi-color-names-vector . [,base02 ,red ,green ,yellow ,blue ,magenta ,cyan ,base00]))))))))


### PR DESCRIPTION
Set the theme background-mode variable to the string "light" or "dark" rather
than the equivalent symbol. This fixes the "Symbol's value as variable is
void: dark" (or light) error that prevents the \*Custom Theme\* buffer loading
when trying to customize a Solarized theme.