### PR TITLE
Add global color variables and related functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,23 @@ colorscheme. To do so, simply customize the `solarized-termcolor` variable to
 Again, I recommend just changing your terminal colors to Solarized values 
 either manually or via one of the many terminal schemes available for import.
 
+Utility variables and functions
+-------------------------------
+
+* All color values are globally accessible as `solarized-base01`, `solarized-blue`,
+  and so forth. These variables are updated when a theme is selected.
+
+* `(solarized-update-definitions)` manually updates the variables for
+  the chosen scheme, so they're still accessible even when you haven't
+  enabled a Solarized theme.
+  
+* `solarized-theme-hook` runs when the color variables are updated. This allows you to
+  rerun any code that uses the base colors with their new values.
+  `(solarized-load-theme)` is required as an alternative to `(load-theme
+  'solarized-[light|dark])` if you want to trigger this hook.
+
+* `(solarized-list-colors-display)` shows the color values in the `*Colors*` buffer.
+
 Advanced Configuration
 ----------------------
 

--- a/color-theme-solarized.el
+++ b/color-theme-solarized.el
@@ -34,7 +34,10 @@ Ported to Emacs by Greg Pfeil, http://ethanschoonover.com/solarized."
        (solarized-color-definitions mode)
      `(,(intern (concat "color-theme-solarized-" (symbol-name mode)))
        ,variables
-       ,@faces))))
+       ,@faces)))
+
+    ;; Manually update the color variables
+    (solarized-update-definitions mode))
 
 ;;;###autoload
 (defun color-theme-solarized-dark ()


### PR DESCRIPTION
Make color values accessible as `solarized-base01`, `solarized-blue` etc, and add a `solarized-theme-hook` that runs when those variables are updated (plus some other related functions). You can then use the color variables in ad-hoc situations:

```emacs-lisp
(defun my-custom-org-setup ()
  (setq org-todo-keyword-faces
    `(("TODO" . (:foreground ,solarized-orange))
      ("HOLD" . (:foreground ,solarized-base3))
      ("DONE" . (:foreground ,solarized-base01))))
  (font-lock-fontify-buffer))
(add-hook 'solarized-theme-hook 'my-custom-org-setup)
```

I'm not certain this should be merged, it's clumsy and I'm not too familiar with the customization system. It's a solution to this situation:

- You have a project with some dedicated setup code where you want to use Solarized base colors.

- You want the base colors to refresh when swapping between the dark and light themes.

- You don't want to write separate code for handling color-theme _and_ the custom theme system.

Is there a more elegant / proper way of achieving this?