### PR TITLE
Fix the `match' face's specification

### DIFF
--- a/solarized-definitions.el
+++ b/solarized-definitions.el
@@ -241,7 +241,7 @@ the \"Gen RGB\" column in solarized-definitions.el to improve them further."
                 (lazy-highlight (,@fmt-revr ,@fg-yellow ,@bg-back)) ; Search
                 (link (,@fmt-undr ,@fg-violet))
                 (link-visited (,@fmt-undr ,@fg-magenta))
-                (match ((t (,@fmt-revr ,@fg-yellow ,@bg-back)))) ; Occur
+                (match (,@fmt-revr ,@fg-yellow ,@bg-back)) ; Occur
                 (menu (,@fg-base0 ,@bg-base02))
                 (minibuffer-prompt (,@fmt-bold ,@fg-cyan)) ; Question
                 (mode-line ; StatusLine


### PR DESCRIPTION
It looks like the `match` face's specification wasn't updated with the recent changes in `master`, causing it to have no effect.

I checked for other instances of the same issue but didn't see any.