### PR TITLE
Add diff-refine-{added,removed} faces

### DIFF
--- a/solarized-definitions.el
+++ b/solarized-definitions.el
@@ -302,6 +302,8 @@ the \"Gen RGB\" column in solarized-definitions.el to improve them further."
                          (diff-changed (,@fg-yellow ,@bg-base02))
                          (diff-removed (,@fg-red ,@bg-base02))
                          (diff-refine-change (,@fg-blue ,@bg-base02))))))
+                (diff-refine-added (:inherit diff-added ,@fmt-revr))
+                (diff-refine-removed (:inherit diff-removed ,@fmt-revr))
                 (diff-file-header (,@bg-back))
                 (diff-header (,@fg-base1 ,@bg-back))
                 ;; IDO


### PR DESCRIPTION
These are used by tools like Magit to show which specific text changed in a changed line (as opposed to added/removed whole lines, which is what `diff-{added,removed}` shows).

In order to mimic the behaviour shown by tools like GitHub I've just reversed the corresponding whole line faces so they stand out.

Screenshot of new behaviour:

![screen shot 2015-05-14 at 10 53 52](https://cloud.githubusercontent.com/assets/1516/7629786/8cc649ec-fa27-11e4-95c4-30150e2f8183.png)
