### PR TITLE
Fix company-mode selected tooltip

### DIFF
--- a/solarized-definitions.el
+++ b/solarized-definitions.el
@@ -732,10 +732,10 @@ the \"Gen RGB\" column in solarized-definitions.el to improve them further."
                 (term-color-white (,@fg-base00))
                 ;; company
                 (company-tooltip (,@fg-base00 ,@bg-base02))
-                (company-tooltip-selection (,@fg-base1 ,@bg-base02))
+                (company-tooltip-selection (,@fg-green ,@bg-base02))
                 (company-tooltip-mouse (,@fg-base1 ,@bg-base02))
-                (company-tooltip-common (,@fg-blue ,@bg-base02))
-                (company-tooltip-common-selection (,@fg-blue ,@bg-base01))
+                (company-tooltip-common (,@fg-blue ,@bg-base02 ,@fmt-undr))
+                (company-tooltip-common-selection (,@fg-green ,@bg-base02 ,@fmt-undr))
                 (company-tooltip-annotation (,@fg-yellow ,@bg-base02))
                 (company-scrollbar-fg (,@bg-base0))
                 (company-scrollbar-bg (,@bg-base02))


### PR DESCRIPTION
The old one had such low contrast that it was invisible. This new scheme matches the scheme used by `ido-mode`, and is more readable.

Before:

![screen shot 2015-05-21 at 22 05 46](https://cloud.githubusercontent.com/assets/1516/7758971/93ec408a-0005-11e5-9ae2-11f81f9aaa12.png)

After:

![screen shot 2015-05-21 at 22 24 40](https://cloud.githubusercontent.com/assets/1516/7759313/365a4b08-0008-11e5-86e7-b9dcbebb2323.png)

