### PR TITLE
Fix whitespace-newline face

### DIFF
--- a/solarized-definitions.el
+++ b/solarized-definitions.el
@@ -702,6 +702,7 @@ the \"Gen RGB\" column in solarized-definitions.el to improve them further."
                 (whitespace-trailing (,@fmt-bold ,@fg-red ,@bg-base02))
                 (whitespace-highlight-face (,@fg-red ,@bg-blue))
                 (whitespace-line (,@fg-magenta))
+                (whitespace-newline (:inherit shadow :slant normal))
                 ;; writegood
                 (writegood-weasels-face (,@fmt-curl-cyan ,@fg-cyan))
                 (writegood-passive-voice-face (,@fg-magenta))


### PR DESCRIPTION
This makes newline symbols to be highlighted according to screenshots ([example1][e1], [example2][e2]).
Visual diff
Before
<img width="31" alt="2016-02-19 16 54 13" src="https://cloud.githubusercontent.com/assets/744471/13175074/b86413ce-d729-11e5-98f9-a3d1cf759493.png">
<img width="38" alt="2016-02-19 16 55 17" src="https://cloud.githubusercontent.com/assets/744471/13175075/b86523ae-d729-11e5-8e17-7fb20faa4ab7.png">
Note, with dark background newline chars are very distractive.
After:
<img width="49" alt="2016-02-19 16 48 46" src="https://cloud.githubusercontent.com/assets/744471/13175083/c5239274-d729-11e5-8bd2-f33c90253558.png">
<img width="41" alt="2016-02-19 16 49 10" src="https://cloud.githubusercontent.com/assets/744471/13175084/c526af36-d729-11e5-91f2-bb1b63b8ba68.png">
Note, if you have `hl-line-mode` enabled it plays nice with new settings: newline char have same foreground color as current line background color and disappears reducing distraction.

Small screenshots looks quite uninformative, here are few bigger ones:
<img width="553" alt="2016-02-19 17 26 42" src="https://cloud.githubusercontent.com/assets/744471/13175687/fe1ba8f6-d72d-11e5-8e8a-a65dce194db9.png">
<img width="548" alt="2016-02-19 17 26 28" src="https://cloud.githubusercontent.com/assets/744471/13175686/fe172e84-d72d-11e5-9e80-3fc607fbb420.png">

One weird thing I've discovered, that current version of solarized theme have different color for newlines, but it is also very distractive (especially with light background), observe:
<img width="556" alt="2016-02-19 17 28 00" src="https://cloud.githubusercontent.com/assets/744471/13175741/4bd360c0-d72e-11e5-8cda-f2b6a55c874c.png">
<img width="551" alt="2016-02-19 17 28 13" src="https://cloud.githubusercontent.com/assets/744471/13175742/4bd4238e-d72e-11e5-8293-f1c4d8a64e62.png">

What do you think?

[e1]:https://raw.githubusercontent.com/altercation/solarized/master/img/screen-haskell-light.png
[e2]:https://raw.githubusercontent.com/altercation/solarized/master/img/screen-haskell-dark.png