### PR TITLE
Add haskell keyword customization

### DIFF
--- a/solarized-definitions.el
+++ b/solarized-definitions.el
@@ -774,7 +774,9 @@ the \"Gen RGB\" column in solarized-definitions.el to improve them further."
                 (undo-tree-visualizer-default-face (:inherit shadow))
                 (undo-tree-visualizer-active-branch-face (:inherit default))
                 (undo-tree-visualizer-unmodified-face (,@fg-cyan))
-                (undo-tree-visualizer-register-face (,@fg-yellow)))))))
+                (undo-tree-visualizer-register-face (,@fg-yellow))
+                ;; haskell
+                (haskell-keyword-face (,@fg-cyan)))))))
 
 ;;;###autoload
 (when (boundp 'custom-theme-load-path)


### PR DESCRIPTION
Make keyword colors match to Vim's version for Haskell source files

Compare `data`, `where` and `let … in` keyword colors

Before:
<img width="744" alt="2016-02-19 17 33 25" src="https://cloud.githubusercontent.com/assets/744471/13176015/9bc72f74-d730-11e5-9960-4c883b6d0a59.png">
After:
<img width="744" alt="2016-02-19 17 46 17" src="https://cloud.githubusercontent.com/assets/744471/13176082/1c5881d8-d731-11e5-8574-3cffb4982067.png">
Vim (default):
<img width="690" alt="2016-02-19 17 33 32" src="https://cloud.githubusercontent.com/assets/744471/13176050/dd0548ea-d730-11e5-8355-2de314b0e4a1.png">
Vim (with improved haskell syntax):
<img width="718" alt="2016-02-19 17 38 11" src="https://cloud.githubusercontent.com/assets/744471/13176056/e8cb04d0-d730-11e5-90dc-b6950d097980.png">

I would be happy to see numbers and punctuation highlight similar to Vim, but both of them are not fontyfied, so I have no good solution for them right now.