### PR TITLE
Fix company-preview-common face

### DIFF
--- a/solarized-definitions.el
+++ b/solarized-definitions.el
@@ -747,7 +747,7 @@ the \"Gen RGB\" column in solarized-definitions.el to improve them further."
                 (company-scrollbar-fg (,@bg-base0))
                 (company-scrollbar-bg (,@bg-base02))
                 (company-preview (,@bg-green))
-                (company-preview-common (,@bg-base02))
+                (company-preview-common (,@fg-base01 ,@bg-base02))
                 (company-template-field (,@fg-base03 ,@bg-yellow))
                 ;; hydra
                 (hydra-face-red (,@fmt-bold ,@fg-red))


### PR DESCRIPTION
In current setup preview part and actual input have same foreground, when current line highlighting is turned on it also have identical backgrounds, making both visually equal
<img width="222" alt="2016-02-22 4 00 00" src="https://cloud.githubusercontent.com/assets/744471/13206090/4f21f4a2-d919-11e5-979d-64951803bfd2.png">
This PR changes foreground colour of preview part making it a bit distinguishable:
<img width="193" alt="2016-02-22 4 00 44" src="https://cloud.githubusercontent.com/assets/744471/13206097/68bb7c76-d919-11e5-8383-553d4b3629dc.png">
