### PR TITLE
Only add solarized to color-themes list if color-themes is bound

### DIFF
--- a/color-theme-solarized.el
+++ b/color-theme-solarized.el
@@ -30,10 +30,11 @@ Ported to Emacs by Greg Pfeil, http://ethanschoonover.com/solarized."
   (color-theme-install
    `(color-theme-solarized () () ,@(solarized-color-definitions))))
 
-(add-to-list 'color-themes
-             `(color-theme-solarized
-               "Solarized"
-               ,solarized-description))
+(when (boundp 'color-themes)
+  (add-to-list 'color-themes
+               `(color-theme-solarized
+                 "Solarized"
+                 ,solarized-description)))
 
 ;;;###autoload
 (defun color-theme-solarized-dark ()


### PR DESCRIPTION
This fixes an issue for newer Emacs complaining that `color-themes` doesn't exist (when it isn't installed)
