### PR TITLE
Add mode-line-buffer-id faces

### DIFF
--- a/solarized-definitions.el
+++ b/solarized-definitions.el
@@ -252,6 +252,8 @@ the \"Gen RGB\" column in solarized-definitions.el to improve them further."
                  (,@fg-base1 ,@bg-base02 ,@fmt-revbb :box nil))
                 (mode-line-inactive    ; StatusLineNC
                  (,@fg-base00 ,@bg-base02 ,@fmt-revbb :box nil))
+                (mode-line-buffer-id (,@fmt-bold :inherit mode-line))
+                (mode-line-buffer-id-inactive (,@fmt-bold :inherit mode-line-inactive))
                 (region (,@fg-base01 ,@bg-base03 ,@fmt-revbb)) ; Visual
                 (secondary-selection (,@bg-base02))
                 (shadow (,@fg-base01))


### PR DESCRIPTION
I noticed the active face popping up in an inactive Powerline when Emacs regained focus. This fixes it.
