### PR TITLE
Add face org-document-info

### DIFF
--- a/solarized-definitions.el
+++ b/solarized-definitions.el
@@ -405,6 +405,7 @@ the \"Gen RGB\" column in solarized-definitions.el to improve them further."
                 (org-formula (:weight bold :slant italic ,@fg-red))
                 (org-code (,@fg-base01))
                 (org-document-title (,@fmt-bold ,@fg-cyan))
+                (org-document-info (,@fg-cyan))
                 (org-document-info-keyword (,@fg-base01))
                 (org-block (,@fg-base01))
                 (org-verbatim (,@fmt-undr ,@fg-base01))


### PR DESCRIPTION
`org-document-info` defaults to dark blue which is nearly unreadable in Solarized Dark mode. Correcting this to `fg-cyan` to match `org-document-title`.  