### PR TITLE
Allow true color (24 bit) display support

### DIFF
--- a/solarized-definitions.el
+++ b/solarized-definitions.el
@@ -190,12 +190,7 @@ LIGHT is non-nil."
   "Generate a full face-spec for face NAME from the Solarized FACESPEC.
 This generates the spec across a variety of displays from the FACESPEC, which
 contains Solarized symbols."
-  `(,name (,@(dark-and-light '((type graphic))
-                             facespec
-                             (cond (solarized-degrade     3)
-                                   (solarized-broken-srgb 2)
-                                   (t                     1)))
-	   ,@(dark-and-light '((min-colors 16777216))
+  `(,name (,@(dark-and-light '((min-colors 16777216))
                              facespec
                              (cond (solarized-degrade     3)
                                    (solarized-broken-srgb 2)

--- a/solarized-definitions.el
+++ b/solarized-definitions.el
@@ -195,6 +195,11 @@ contains Solarized symbols."
                              (cond (solarized-degrade     3)
                                    (solarized-broken-srgb 2)
                                    (t                     1)))
+	   ,@(dark-and-light '((min-colors 16777216))
+                             facespec
+                             (cond (solarized-degrade     3)
+                                   (solarized-broken-srgb 2)
+                                   (t                     1)))
            ;; only produce 256-color term-specific settings if ‘solarized-termcolors’ is 256
            ,@(when (= solarized-termcolors 256)
                (dark-and-light '((type tty) (min-colors 256)) facespec 3))


### PR DESCRIPTION
I've been trying to find out why this theme looks completely wrong in the ghostty terminal even when the terminal's theme is set to Solarized, which sets the color palette. It turns out when using TERM=xterm-ghostty, (display-color-cells) returns 16777216, which is not (min-colors 256) so it falls through to 8-and-16.

I just replicated the (type graphic) branch for this case and now emacs is solarized even when the terminal palette is not set appropriately.